### PR TITLE
Fix wrong example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ restic_install_path: '/var/lib/restic'
 restic_version: '0.7.3'
 
 restic_repos:
-  name: example
-  url: '/backup'
-  password: 'foo'
+  - name: example
+    url: '/backup'
+    password: 'foo'
 ```
 
 Example configuration


### PR DESCRIPTION
The `restic_repos` is meant to be an array to iterate over.