### PR TITLE
Updates need to write restic binary

### DIFF
--- a/tasks/install_github.yml
+++ b/tasks/install_github.yml
@@ -18,8 +18,6 @@
 
 - name: Decompress the binary
   shell: bzip2 -dc {{ get_url_restic.dest }} > {{ restic_install_path }}/restic
-  args:
-    creates: '{{ restic_install_path }}/restic'
 
 - name: Ensure permissions are correct
   file:


### PR DESCRIPTION
I tried to update `restic` to the latest version using Github but the binary would not be updated since `creates` directive would skip the task since the binary is already there.

With this PR we propose to remove the `creates` directive. The down side is that the binary will be created every time, it's a shame that `unarchive` ansible module doesn't support `bzip2`. That would solve the issue... but probably we can find another way to solve this.

What do you think?