### PR TITLE
Security Hardening cron files

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,4 +16,4 @@
   template:
     src: 'restic.cron.j2'
     dest: '/etc/cron.d/restic-{{ item.name }}'
-    mode: '0644'
+    mode: '0640'


### PR DESCRIPTION
Since this file stores passwords to remote systems (like AWS S3 bucket) it would be good if it is not readable by other users.