### PR TITLE
Trim environment variables

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -18,7 +18,11 @@
         url: '/backup'
         password: 'testpassword'
         init: True
-
+      - name: blocktest
+        url: '/backup-block'
+        password: |
+          supersecret
+        init: True
     restic_jobs:
       - at: '0 6  * * *'
         type: 'db_mysql'

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -47,3 +47,10 @@ def test_repo(host):
             'RESTIC_PASSWORD="testpassword" restic -r /backup snapshots'
         )
     assert cmd.rc == 0
+
+def test_block_no_whitespace(host):
+    f = host.file('/etc/cron.d/restic-test')
+
+    assert f.exists
+    with host.sudo():
+        assert f.contains('RESTIC_PASSWORD="supersecret"')

--- a/templates/restic.cron.j2
+++ b/templates/restic.cron.j2
@@ -5,20 +5,20 @@
 # {{ ansible_managed }}
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-RESTIC_REPOSITORY="{{ item.url }}"
-RESTIC_PASSWORD="{{ item.password }}"
+RESTIC_REPOSITORY="{{ item.url | trim }}"
+RESTIC_PASSWORD="{{ item.password | trim }}"
 {% if item.aws_access_key_id is defined %}
-AWS_ACCESS_KEY_ID="{{ item.aws_access_key_id }}"
-AWS_SECRET_ACCESS_KEY="{{ item.aws_secret_access_key }}"
+AWS_ACCESS_KEY_ID="{{ item.aws_access_key_id | trim }}"
+AWS_SECRET_ACCESS_KEY="{{ item.aws_secret_access_key | trim }}"
 {% elif item.b2_account_id is defined %}
-B2_ACCOUNT_ID="{{ item.b2_account_id }}"
-B2_ACCOUNT_KEY="{{ item.b2_account_key }}"
+B2_ACCOUNT_ID="{{ item.b2_account_id | trim }}"
+B2_ACCOUNT_KEY="{{ item.b2_account_key | trim }}"
 {% elif item.azure_account_name is defined %}
-AZURE_ACCOUNT_NAME="{{ item.azure_account_name }}"
-AZURE_ACCOUNT_KEY="{{ item.azure_account_key }}"
+AZURE_ACCOUNT_NAME="{{ item.azure_account_name | trim }}"
+AZURE_ACCOUNT_KEY="{{ item.azure_account_key | trim }}"
 {% elif item.os_storage_url is defined %}
-OS_STORAGE_URL="{{ item.os_storage_url }}"
-OS_AUTH_TOKEN="{{ item.os_auth_token }}"
+OS_STORAGE_URL="{{ item.os_storage_url | trim }}"
+OS_AUTH_TOKEN="{{ item.os_auth_token | trim }}"
 {% endif %}
 {% set restic_stdin = '| restic backup --stdin' %}
 {% macro tags(tags) -%}


### PR DESCRIPTION
Variables that use the 'block' syntax (like the ones from Ansible vault)
contain a trailing newline, leading to this newline being inserted in
the cron-file's output:

```yaml
restic_repos:
  - password: |
    mysecretpassword
```

```
RESTIC_PASSWORD="mysecretpassword
"
```

Which in turn lead to existing backups failing because of a wrong key.

This PR trims the environment variables of leading and trailing newlines to prevent this.