### PR TITLE
Bump restic version to 0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Role Variables
 --------------
 
 ```yaml
-restic_version: '0.8.3'
+restic_version: '0.9.2'
 restic_url: ''
 
 restic_download_path: '/opt/restic'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-restic_version: '0.8.3'
+restic_version: '0.9.2'
 restic_url: ''
 
 restic_download_path: '/opt/restic'


### PR DESCRIPTION
This MR allows to use ansible-restic with the latest stable ansible version.